### PR TITLE
Fix API compatibility issues and update response structures

### DIFF
--- a/print.go
+++ b/print.go
@@ -11,21 +11,31 @@ import (
 	"time"
 )
 
+// UserMapping represents user mapping for print job assignment.
+type UserMapping struct {
+	Key   string `json:"key"`   // AzureObjectId, AzureUPN, SAMAccountName, OnPremImmutableId, OnPremUpn, Email
+	Value string `json:"value"` // Value to filter for
+}
+
 // PrintJob represents a print job submission.
 type PrintJob struct {
 	PrinterID     string         `json:"-"` // Not sent in body, used in URL
-	Title         string         `json:"title,omitempty"`
-	User          string         `json:"user,omitempty"`
-	PDL           string         `json:"PDL,omitempty"`
-	// v1.1 properties
-	Color           *bool  `json:"color,omitempty"`
-	Duplex          string `json:"duplex,omitempty"`      // NONE, SHORT_EDGE, LONG_EDGE
-	PageOrientation string `json:"page_orientation,omitempty"` // PORTRAIT, LANDSCAPE, AUTO
-	Copies          *int   `json:"copies,omitempty"`
-	MediaSize       string `json:"media_size,omitempty"`
-	Scaling         string `json:"scaling,omitempty"`     // NOSCALE, SHRINK, FIT
-	TestMode        bool   `json:"-"`                     // Not sent to API
-	UseV11          bool   `json:"-"`                     // Use v1.1 API
+	QueueID       string         `json:"-"` // Not sent in body, used in URL
+	Title         string         `json:"-"` // Not sent in body, used in URL query
+	User          string         `json:"-"` // Not sent in body, used in URL query
+	PDL           string         `json:"-"` // Not sent in body, used in URL query
+	// v1.1 properties (sent in body)
+	Color           *bool        `json:"color,omitempty"`
+	Duplex          string       `json:"duplex,omitempty"`            // NONE, SHORT_EDGE, LONG_EDGE
+	PageOrientation string       `json:"page_orientation,omitempty"`  // PORTRAIT, LANDSCAPE, AUTO
+	Copies          *int         `json:"copies,omitempty"`
+	MediaSize       string       `json:"media_size,omitempty"`
+	Scaling         string       `json:"scaling,omitempty"`           // NOSCALE, SHRINK, FIT
+	UserMapping     *UserMapping `json:"userMapping,omitempty"`
+	// Control fields
+	ReleaseImmediately *bool `json:"-"`  // Not sent in body, used in URL query
+	TestMode           bool  `json:"-"`  // Not sent in body, used in URL query
+	UseV11             bool  `json:"-"`  // Use v1.1 API
 }
 
 // SubmitResponse represents the response from submitting a print job.
@@ -33,25 +43,38 @@ type SubmitResponse struct {
 	Response
 	Job struct {
 		ID          string `json:"id"`
-		CreateTime  int64  `json:"createTime"`
-		UpdateTime  int64  `json:"updateTime"`
+		CreateTime  string `json:"createTime"`  // ISO format timestamp
+		UpdateTime  string `json:"updateTime"`  // ISO format timestamp
 		Status      string `json:"status"`
 		OwnerID     string `json:"ownerId"`
 		ContentType string `json:"contentType"`
 		Title       string `json:"title"`
+		Links       struct {
+			Self struct {
+				Href string `json:"href"`
+			} `json:"self"`
+			Printer struct {
+				Href string `json:"href"`
+			} `json:"printer"`
+			ChangeOwner struct {
+				Href      string `json:"href"`
+				Templated bool   `json:"templated"`
+			} `json:"changeOwner"`
+		} `json:"_links"`
 	} `json:"job"`
 	UploadLinks []struct {
 		URL     string            `json:"url"`
 		Headers map[string]string `json:"headers"`
-		Type    string            `json:"type"` // "Azure" or "GCP"
+		Type    string            `json:"type,omitempty"` // "Azure" or "GCP" - not always present
 	} `json:"uploadLinks"`
 	Links struct {
-		Self struct {
-			Href string `json:"href"`
-		} `json:"self"`
 		UploadCompleted struct {
 			Href string `json:"href"`
 		} `json:"uploadCompleted"`
+		ChangeOwner struct {
+			Href      string `json:"href"`
+			Templated bool   `json:"templated"`
+		} `json:"changeOwner"`
 	} `json:"_links"`
 }
 
@@ -62,11 +85,13 @@ type CompleteUploadRequest struct {
 
 // PrintOptions represents print job options.
 type PrintOptions struct {
-	Copies      int    `json:"copies,omitempty"`
-	Color       bool   `json:"color,omitempty"`
-	Duplex      string `json:"duplex,omitempty"` // "none", "long-edge", "short-edge"
-	PageRange   string `json:"pageRange,omitempty"`
-	Orientation string `json:"orientation,omitempty"` // "portrait", "landscape"
+	Copies          int    `json:"copies,omitempty"`      // Number of copies (positive integer)
+	Color           bool   `json:"color,omitempty"`       // true for color, false for monochrome
+	Duplex          string `json:"duplex,omitempty"`      // "none", "long-edge", "short-edge"
+	Orientation     string `json:"orientation,omitempty"` // "portrait", "landscape"
+	MediaSize       string `json:"mediaSize,omitempty"`   // Paper size: A0-A5, B4-B5, LETTER, LEGAL, etc.
+	Scaling         string `json:"scaling,omitempty"`     // "NOSCALE", "SHRINK", "FIT"
+	PageRange       string `json:"pageRange,omitempty"`   // Page range (not used in v1.1 API)
 }
 
 // Submit creates a new print job.
@@ -75,7 +100,10 @@ func (c *Client) Submit(ctx context.Context, job *PrintJob) (*SubmitResponse, er
 		return nil, fmt.Errorf("tenant ID is required for job submission")
 	}
 
-	endpoint := fmt.Sprintf(submitEndpoint, c.tenantID, job.PrinterID)
+	if job.QueueID == "" {
+		return nil, fmt.Errorf("queue ID is required for job submission")
+	}
+	endpoint := fmt.Sprintf(submitEndpoint, c.tenantID, job.PrinterID, job.QueueID)
 	
 	// Add query parameters
 	params := url.Values{}
@@ -91,6 +119,12 @@ func (c *Client) Submit(ctx context.Context, job *PrintJob) (*SubmitResponse, er
 	if c.testMode || job.TestMode {
 		params.Set("test", "true")
 	}
+	// Handle releaseImmediately parameter (default is true)
+	if job.ReleaseImmediately != nil && !*job.ReleaseImmediately {
+		params.Set("releaseImmediately", "false")
+	} else if job.ReleaseImmediately == nil {
+		params.Set("releaseImmediately", "true")
+	}
 	
 	if len(params) > 0 {
 		endpoint += "?" + params.Encode()
@@ -103,7 +137,6 @@ func (c *Client) Submit(ctx context.Context, job *PrintJob) (*SubmitResponse, er
 	if job.UseV11 || job.Color != nil || job.Duplex != "" || job.PageOrientation != "" || 
 	   job.Copies != nil || job.MediaSize != "" || job.Scaling != "" {
 		headers["version"] = "1.1"
-		headers["Content-Type"] = "application/json"
 		
 		// Build v1.1 request body
 		v11Body := make(map[string]any)
@@ -125,10 +158,14 @@ func (c *Client) Submit(ctx context.Context, job *PrintJob) (*SubmitResponse, er
 		if job.Scaling != "" {
 			v11Body["scaling"] = job.Scaling
 		}
-		
-		if len(v11Body) > 0 {
-			requestBody = v11Body
+		if job.UserMapping != nil {
+			v11Body["userMapping"] = job.UserMapping
+		} else {
+			v11Body["userMapping"] = nil
 		}
+		
+		// Always send body for v1.1, even if empty
+		requestBody = v11Body
 	}
 
 	resp, err := c.doRequestWithHeaders(ctx, http.MethodPost, endpoint, requestBody, headers)
@@ -205,7 +242,7 @@ func (c *Client) CompleteUpload(ctx context.Context, completeURL string) error {
 }
 
 // PrintFile prints a file using Printix.
-func (c *Client) PrintFile(ctx context.Context, printerID, title, filePath string, options *PrintOptions) error {
+func (c *Client) PrintFile(ctx context.Context, printerID, queueID, title, filePath string, options *PrintOptions) error {
 	// Read the file
 	data, err := os.ReadFile(filePath)
 	if err != nil {
@@ -230,8 +267,9 @@ func (c *Client) PrintFile(ctx context.Context, printerID, title, filePath strin
 	// Create print job
 	job := &PrintJob{
 		PrinterID: printerID,
+		QueueID:   queueID,
 		Title:     title,
-		User:      "MTS API",
+		User:      c.userIdentifier,
 		PDL:       pdl,
 		TestMode:  c.testMode,
 	}
@@ -260,6 +298,13 @@ func (c *Client) PrintFile(ctx context.Context, printerID, title, filePath strin
 			job.PageOrientation = "PORTRAIT"
 		case "landscape":
 			job.PageOrientation = "LANDSCAPE"
+		}
+		// Add new v1.1 options
+		if options.MediaSize != "" {
+			job.MediaSize = options.MediaSize
+		}
+		if options.Scaling != "" {
+			job.Scaling = options.Scaling
 		}
 	}
 
@@ -288,12 +333,13 @@ func (c *Client) PrintFile(ctx context.Context, printerID, title, filePath strin
 }
 
 // PrintData prints raw data using Printix.
-func (c *Client) PrintData(ctx context.Context, printerID, title string, data []byte, pdl string, options *PrintOptions) error {
+func (c *Client) PrintData(ctx context.Context, printerID, queueID, title string, data []byte, pdl string, options *PrintOptions) error {
 	// Create print job
 	job := &PrintJob{
 		PrinterID: printerID,
+		QueueID:   queueID,
 		Title:     title,
-		User:      "MTS API",
+		User:      c.userIdentifier,
 		PDL:       pdl,
 		TestMode:  c.testMode,
 	}
@@ -322,6 +368,13 @@ func (c *Client) PrintData(ctx context.Context, printerID, title string, data []
 			job.PageOrientation = "PORTRAIT"
 		case "landscape":
 			job.PageOrientation = "LANDSCAPE"
+		}
+		// Add new v1.1 options
+		if options.MediaSize != "" {
+			job.MediaSize = options.MediaSize
+		}
+		if options.Scaling != "" {
+			job.Scaling = options.Scaling
 		}
 	}
 

--- a/printer.go
+++ b/printer.go
@@ -10,16 +10,16 @@ import (
 
 // Printer represents a Printix printer.
 type Printer struct {
-	ID               string                 `json:"id"`
-	Name             string                 `json:"name"`
-	ConnectionStatus string                 `json:"connectionStatus,omitempty"`
-	PrinterSignID    string                 `json:"printerSignId,omitempty"`
-	Location         string                 `json:"location,omitempty"`
-	Model            string                 `json:"model,omitempty"`
-	Vendor           string                 `json:"vendor,omitempty"`
-	SerialNo         string                 `json:"serialNo,omitempty"`
-	Capabilities     PrinterCapabilities    `json:"capabilities,omitempty"`
-	Links            map[string]interface{} `json:"_links,omitempty"`
+	ID               string              `json:"id"`
+	Name             string              `json:"name"`
+	ConnectionStatus string              `json:"connectionStatus,omitempty"`
+	PrinterSignID    string              `json:"printerSignId,omitempty"`
+	Location         string              `json:"location,omitempty"`
+	Model            string              `json:"model,omitempty"`
+	Vendor           string              `json:"vendor,omitempty"`
+	SerialNo         string              `json:"serialNo,omitempty"`
+	Capabilities     PrinterCapabilities `json:"capabilities,omitempty"`
+	Links            PrinterLinks        `json:"_links,omitempty"`
 }
 
 // PrinterCapabilities represents printer capabilities.
@@ -30,7 +30,7 @@ type PrinterCapabilities struct {
 		} `json:"media_size,omitempty"`
 		SupportedContentType []ContentType `json:"supported_content_type,omitempty"`
 		Copies               struct {
-			Default int `json:"default,omitempty"`
+			Default int `json:"defaultz,omitempty"`
 			Max     int `json:"max,omitempty"`
 		} `json:"copies,omitempty"`
 		Color struct {
@@ -76,18 +76,38 @@ type LocalizedString struct {
 	Value  string `json:"value"`
 }
 
+// PrinterLinks represents HAL links for a printer.
+type PrinterLinks struct {
+	Self   Link `json:"self"`
+	Submit Link `json:"submit"`
+	Jobs   Link `json:"jobs"`
+}
+
+// Link represents a HAL link.
+type Link struct {
+	Href      string `json:"href"`
+	Templated bool   `json:"templated,omitempty"`
+}
+
 // PrintersResponse represents the HAL+JSON response from listing printers.
 type PrintersResponse struct {
-	Links    map[string]interface{} `json:"_links"`
-	Success  bool                   `json:"success"`
-	Message  string                 `json:"message"`
-	Printers []Printer              `json:"printers"`
+	Links    PrintersResponseLinks `json:"_links"`
+	Success  bool                  `json:"success"`
+	Message  string                `json:"message"`
+	Printers []Printer             `json:"printers"`
 	Page     struct {
 		Size          int `json:"size"`
 		TotalElements int `json:"totalElements"`
 		TotalPages    int `json:"totalPages"`
 		Number        int `json:"number"`
 	} `json:"page"`
+}
+
+// PrintersResponseLinks represents HAL links for printers response.
+type PrintersResponseLinks struct {
+	Self Link  `json:"self"`
+	Next *Link `json:"next,omitempty"`
+	Prev *Link `json:"prev,omitempty"`
 }
 
 // GetPrintersOptions represents options for listing printers.
@@ -183,9 +203,9 @@ func (c *Client) GetPrinter(ctx context.Context, printerID string) (*Printer, er
 	}
 
 	var printerResp struct {
-		Links   map[string]interface{} `json:"_links"`
-		Success bool                   `json:"success"`
-		Message string                 `json:"message"`
+		Links   PrinterLinks `json:"_links"`
+		Success bool         `json:"success"`
+		Message string       `json:"message"`
 		Printer
 	}
 


### PR DESCRIPTION
## Summary
This PR fixes several API compatibility issues discovered while testing against the actual Printix API endpoints.

## Changes

### 1. User Identifier Configuration
- Added `userIdentifier` field to Client struct
- Created `WithUserIdentifier()` option to configure it (defaults to "API Client")
- Replaced hardcoded "MTS API" strings with configurable identifier

### 2. Queue ID Support
- Added `QueueID` field to PrintJob struct
- Updated Submit endpoint to use correct format: `/printers/{printerId}/queues/{queueId}/submit`
- Updated PrintFile and PrintData to accept separate queueID parameter
- **Breaking change**: QueueID is now required (no backward compatibility)

### 3. v1.1 API Compatibility
- Fixed v1.1 API request format to match documentation:
  - `title`, `user`, `PDL` parameters stay in query string (not body)
  - Added `version: 1.1` header for v1.1 features
  - Request body only contains v1.1 specific fields
- Added support for new v1.1 fields:
  - `userMapping` for user assignment
  - `releaseImmediately` parameter (defaults to true)
  - `MediaSize` and `Scaling` in PrintOptions

### 4. Response Structure Fixes
- Fixed SubmitResponse to match actual API response:
  - Changed timestamps from `int64` to `string` (ISO format)
  - Added nested `_links` section within job object
  - Updated root `_links` structure
- Fixed Printer response structures:
  - Fixed `Copies.Default` field (API returns "defaultz")
  - Added proper HAL link structures instead of generic maps

## Test plan
- [x] All existing tests pass
- [x] Linter passes with no issues
- [x] Tested against actual Printix API endpoints
- [ ] Manual testing of print job submission
- [ ] Verify backward compatibility impact is acceptable

## Breaking Changes
1. `PrintFile` signature changed: `PrintFile(ctx, printerID, queueID, title, filePath, options)`
2. `PrintData` signature changed: `PrintData(ctx, printerID, queueID, title, data, pdl, options)`
3. `Submit` now requires `QueueID` to be set (returns error if empty)

🤖 Generated with [Claude Code](https://claude.ai/code)